### PR TITLE
Log the posted queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/pipedown/try_out_noise#readme",
   "dependencies": {
+    "access-log": "^0.3.0",
     "async": "^2.3.0",
     "nconf": "^0.8.4",
     "noise-search": "^0.2.0"


### PR DESCRIPTION
Log to stdout the queries in access log-like format. The timestamp
is an ISO date and that the POSTed query is appended at the end.

Example:

    127.0.0.1 - - [2017-04-26T22:58:53.105Z] "POST /query HTTP/1.1" 200 - "http://0.0.0.0:3000/" "Mozilla/5.0 (X11; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0" | find {"name": ~= "Star Trek"}\nreturn .name