### PR TITLE
Add parallelism for queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # try_out_noise
 Demo to let users try out Noise queries in the browser
+
+You can set the following environment variables:
+
+ - `NOISE_QUERY_INDEXES` (default: 4): Number of indexes that are opened for querying. This is also the number of queries that can run in parallel.
+ - `NOISE_MAX_WAITING_CLIENTS` (default: 10): Number of clients that will be queued up before they return with an error.
+ - `NOISE_ACQUIRE_TIMEOUT` (default: 5000): The time in milliseconds that will be be tried to acquire an index to query on. This is for the waiting clients.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "dependencies": {
     "access-log": "^0.3.0",
     "async": "^2.3.0",
+    "generic-pool": "^3.1.7",
     "nconf": "^0.8.4",
-    "noise-search": "^0.2.0"
+    "noise-search": "^0.2.0",
+    "sleep-promise": "^2.0.0"
   }
 }


### PR DESCRIPTION
It's now possible to run several queries in parallel with opening the
index several times. A pool is used to manage the resources. If no
free index is available, it will be queued for a certain time. If no
index becomes available for a certain time, an error will be returned
(`Too much load on the server, please try again`).

Some parameters for the pool can be set with environment
variables:

 - `NOISE_QUERY_INDEXES` (default: 4): Number of indexes that
   are opened for querying. This is also the number of queries
   that can run in parallel.
 - `NOISE_MAX_WAITING_CLIENTS` (default: 10): Number of clients
   that will be queued up before they return with an error.
 - `NOISE_ACQUIRE_TIMEOUT` (default: 5000): The time in
   milliseconds that will be be tried to acquire an index to
   query on. This is for the waiting clients.