### PR TITLE
Use original IP address if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ getLatestShows(Math.floor(nconf.get("last_indexed") / 250));
 const hostname = '0.0.0.0';
 const port = 3000;
 const maxPostSize = 4 * 1024;
-const accessLogFormat = ':ip - :userID [:endDate] ":method :url :protocol/:httpVersion" :statusCode :contentLength ":referer" ":userAgent"';
+const accessLogFormat = ':Xip - :userID [:endDate] ":method :url :protocol/:httpVersion" :statusCode :contentLength ":referer" ":userAgent"';
 const escapeNewlineRegexp = /\n|\r\n|\r/g;
 const headers = {
     'Content-Type': "application/json",


### PR DESCRIPTION
If the request if forwarded, e.g. by Nginx, the `X-Forwarded-For`
header is set. Use that IP address instead. Else it would only
show `127.0.0.1` in the logs.