### PR TITLE
Bind to localhost

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ getLatestShows(Math.floor(nconf.get("last_indexed") / 250));
 
 // start the webserver
 
-const hostname = '0.0.0.0';
+const hostname = '127.0.0.1';
 const port = 3000;
 const maxPostSize = 4 * 1024;
 const accessLogFormat = ':Xip - :userID [:endDate] ":method :url :protocol/:httpVersion" :statusCode :contentLength ":referer" ":userAgent"';


### PR DESCRIPTION
All requests to this backend should be over Nginx as it implements
basic throttling. Hence bind it to localhost so that no outside
requests are possible anymore.