### PR TITLE
Make Noise server URL more flexible

### DIFF
--- a/ember/app/components/noise-query.js
+++ b/ember/app/components/noise-query.js
@@ -11,7 +11,7 @@ export default Ember.Component.extend({
   actions: {
     doQuery() {
       const query = this.$('textarea').val();
-      Ember.$.post(ENV.noiseUrl, query)
+      Ember.$.post('//' + window.location.hostname + ENV.noiseUrl, query)
         .done(data => {
           this.set('results', data);
         })

--- a/ember/config/environment.js
+++ b/ember/config/environment.js
@@ -29,7 +29,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    ENV.noiseUrl = '//localhost:3000/query'
+    ENV.noiseUrl = ':3000/query'
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
On development setups its now possible to run the application from
non localhost as long as the application as well as the Noise index
runs on the same server (but on different ports).